### PR TITLE
fix useItem could be overwritten by null

### DIFF
--- a/simulator.es
+++ b/simulator.es
@@ -289,7 +289,9 @@ function damageShip(fromShip, toShip, damage) {
   toShip.nowHP  -= damage
   toShip.lostHP += damage
   let item   = useItem(toShip)
-  toShip.useItem = item
+  if (item) {
+    toShip.useItem = item
+  }
   let toHP   = toShip.nowHP
   // `toShip.*` is updated in place
   return {fromHP, toHP, item}


### PR DESCRIPTION
Only overwrites ship.useItem when item is a number